### PR TITLE
remove unneccesary rm -r

### DIFF
--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Package Lambda function
         run: |
-          rm -r ./package/*dist-info __pycache__
           cd package
           zip -r ../lambda_layer.zip .
 


### PR DESCRIPTION
Not needed with the use of `--no-cache-dir` in `pip install --no-cache-dir -r requirements.txt --target ./package`